### PR TITLE
Avoid glimpse telemetry

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,6 +143,8 @@ module.exports = yeoman.generators.Base.extend({
                 this.destinationPath(path.join(this.projectName, 'Dockerfile')));
             this.fs.copy(this.templatePath(path.join('unit.sh')),
                 this.destinationPath(path.join(this.projectName, 'unit.sh')));
+            this.fs.copy(this.templatePath(path.join('glimpse.config.json')),
+                this.destinationPath(path.join(this.projectName, 'glimpse.config.json')));
         },
 
         end: function() {

--- a/generators/app/templates/glimpse.config.json
+++ b/generators/app/templates/glimpse.config.json
@@ -1,0 +1,3 @@
+{
+  "telemetry.enabled": false
+}


### PR DESCRIPTION
Glimpse (a Microsoft proprietary software) do telemetry as default configuration.
So I think It is better to avoid it. 